### PR TITLE
Fix for #133 - Support interface types in parameterised types

### DIFF
--- a/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
+++ b/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
@@ -610,6 +610,7 @@ public class ClassUtil {
       String name = typeVariable.getName();
       name = removeAll(name, "capture#\\d+-of\\s+");
       name = removeAll(name, " class");
+      name = removeAll(name, " interface");
       typeDeclaration.append(name);
     } else if (!isJavaLangType(type)) {
       // it's a normal class but not in java.lang => add the package name

--- a/src/test/java/org/assertj/assertions/generator/data/nba/Player.java
+++ b/src/test/java/org/assertj/assertions/generator/data/nba/Player.java
@@ -44,6 +44,7 @@ public class Player {
   private List<int[]> points = new ArrayList<>();
   private String[] previousTeamNames = {};
   public List<? extends Team> previousTeams = new ArrayList<>();
+  private List<? extends CharSequence> previousNames = new ArrayList<>();
 
   private boolean bad;
 
@@ -196,6 +197,10 @@ public class Player {
 
   public float getSize() {
     return size;
+  }
+
+  public List<? extends CharSequence> getPreviousNames() {
+    return previousNames;
   }
 
   @Override

--- a/src/test/java/org/assertj/assertions/generator/description/converter/ClassToClassDescriptionConverterTest.java
+++ b/src/test/java/org/assertj/assertions/generator/description/converter/ClassToClassDescriptionConverterTest.java
@@ -61,7 +61,7 @@ public class ClassToClassDescriptionConverterTest implements NestedClassesTest, 
     assertThat(classDescription.getFullyQualifiedClassName()).isEqualTo("org.assertj.assertions.generator.data.nba.Player");
     assertThat(classDescription.getFullyQualifiedOuterClassName()).isEqualTo("org.assertj.assertions.generator.data.nba.Player");
     assertThat(classDescription.getFullyQualifiedClassNameWithoutGenerics()).isEqualTo(classDescription.getFullyQualifiedClassName());
-    assertThat(classDescription.getGettersDescriptions()).hasSize(19);
+    assertThat(classDescription.getGettersDescriptions()).hasSize(20);
     assertThat(classDescription.getAssertClassName()).isEqualTo("PlayerAssert");
     assertThat(classDescription.getAssertClassFilename()).isEqualTo("PlayerAssert.java");
     assertThat(classDescription.getFullyQualifiedAssertClassName()).isEqualTo("org.assertj.assertions.generator.data.nba.PlayerAssert");

--- a/src/test/resources/AbstractPlayerAssert.expected.txt
+++ b/src/test/resources/AbstractPlayerAssert.expected.txt
@@ -350,6 +350,159 @@ public abstract class AbstractPlayerAssert<S extends AbstractPlayerAssert<S, A>,
   }
 
   /**
+   * Verifies that the actual Player's previousNames contains the given java.lang.CharSequence elements.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public S hasPreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains the given java.lang.CharSequence elements in Collection.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public S hasPreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return myself; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains <b>only</b> the given java.lang.CharSequence elements and nothing else in whatever order.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public S hasOnlyPreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains <b>only</b> the given java.lang.CharSequence elements in Collection and nothing else in whatever order.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public S hasOnlyPreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return myself; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames does not contain the given java.lang.CharSequence elements.
+   *
+   * @param previousNames the given elements that should not be in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames contains any given java.lang.CharSequence elements.
+   */
+  public S doesNotHavePreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames does not contain the given java.lang.CharSequence elements in Collection.
+   *
+   * @param previousNames the given elements that should not be in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames contains any given java.lang.CharSequence elements.
+   */
+  public S doesNotHavePreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return myself; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player has no previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames is not empty.
+   */
+  public S hasNoPreviousNames() {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // we override the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting :\n  <%s>\nnot to have previousNames but had :\n  <%s>";
+
+    // check
+    if (actual.getPreviousNames().iterator().hasNext()) {
+      failWithMessage(assertjErrorMessage, actual, actual.getPreviousNames());
+    }
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+
+  /**
    * Verifies that the actual Player's previousTeamNames contains the given String elements.
    * @param previousTeamNames the given elements that should be contained in actual Player's previousTeamNames.
    * @return this assertion object.

--- a/src/test/resources/AbstractPlayerAssert.generated.in.custom.package.expected.txt
+++ b/src/test/resources/AbstractPlayerAssert.generated.in.custom.package.expected.txt
@@ -351,6 +351,159 @@ public abstract class AbstractPlayerAssert<S extends AbstractPlayerAssert<S, A>,
   }
 
   /**
+   * Verifies that the actual Player's previousNames contains the given java.lang.CharSequence elements.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public S hasPreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains the given java.lang.CharSequence elements in Collection.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public S hasPreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return myself; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains <b>only</b> the given java.lang.CharSequence elements and nothing else in whatever order.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public S hasOnlyPreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains <b>only</b> the given java.lang.CharSequence elements in Collection and nothing else in whatever order.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public S hasOnlyPreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return myself; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames does not contain the given java.lang.CharSequence elements.
+   *
+   * @param previousNames the given elements that should not be in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames contains any given java.lang.CharSequence elements.
+   */
+  public S doesNotHavePreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames does not contain the given java.lang.CharSequence elements in Collection.
+   *
+   * @param previousNames the given elements that should not be in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames contains any given java.lang.CharSequence elements.
+   */
+  public S doesNotHavePreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return myself; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player has no previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames is not empty.
+   */
+  public S hasNoPreviousNames() {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // we override the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting :\n  <%s>\nnot to have previousNames but had :\n  <%s>";
+
+    // check
+    if (actual.getPreviousNames().iterator().hasNext()) {
+      failWithMessage(assertjErrorMessage, actual, actual.getPreviousNames());
+    }
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+
+  /**
    * Verifies that the actual Player's previousTeamNames contains the given String elements.
    * @param previousTeamNames the given elements that should be contained in actual Player's previousTeamNames.
    * @return this assertion object.

--- a/src/test/resources/PlayerAssert.flat.expected.txt
+++ b/src/test/resources/PlayerAssert.flat.expected.txt
@@ -361,6 +361,159 @@ public class PlayerAssert extends AbstractObjectAssert<PlayerAssert, Player> {
   }
 
   /**
+   * Verifies that the actual Player's previousNames contains the given java.lang.CharSequence elements.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public PlayerAssert hasPreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains the given java.lang.CharSequence elements in Collection.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public PlayerAssert hasPreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains <b>only</b> the given java.lang.CharSequence elements and nothing else in whatever order.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public PlayerAssert hasOnlyPreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains <b>only</b> the given java.lang.CharSequence elements in Collection and nothing else in whatever order.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public PlayerAssert hasOnlyPreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames does not contain the given java.lang.CharSequence elements.
+   *
+   * @param previousNames the given elements that should not be in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames contains any given java.lang.CharSequence elements.
+   */
+  public PlayerAssert doesNotHavePreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames does not contain the given java.lang.CharSequence elements in Collection.
+   *
+   * @param previousNames the given elements that should not be in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames contains any given java.lang.CharSequence elements.
+   */
+  public PlayerAssert doesNotHavePreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player has no previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames is not empty.
+   */
+  public PlayerAssert hasNoPreviousNames() {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // we override the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting :\n  <%s>\nnot to have previousNames but had :\n  <%s>";
+
+    // check
+    if (actual.getPreviousNames().iterator().hasNext()) {
+      failWithMessage(assertjErrorMessage, actual, actual.getPreviousNames());
+    }
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+
+  /**
    * Verifies that the actual Player's previousTeamNames contains the given String elements.
    * @param previousTeamNames the given elements that should be contained in actual Player's previousTeamNames.
    * @return this assertion object.

--- a/src/test/resources/PlayerAssert.generated.in.custom.package.flat.expected.txt
+++ b/src/test/resources/PlayerAssert.generated.in.custom.package.flat.expected.txt
@@ -362,6 +362,159 @@ public class PlayerAssert extends AbstractObjectAssert<PlayerAssert, Player> {
   }
 
   /**
+   * Verifies that the actual Player's previousNames contains the given java.lang.CharSequence elements.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public PlayerAssert hasPreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains the given java.lang.CharSequence elements in Collection.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public PlayerAssert hasPreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContains(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains <b>only</b> the given java.lang.CharSequence elements and nothing else in whatever order.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public PlayerAssert hasOnlyPreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames contains <b>only</b> the given java.lang.CharSequence elements in Collection and nothing else in whatever order.
+   * @param previousNames the given elements that should be contained in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames does not contain all given java.lang.CharSequence elements.
+   */
+  public PlayerAssert hasOnlyPreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
+    Iterables.instance().assertContainsOnly(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames does not contain the given java.lang.CharSequence elements.
+   *
+   * @param previousNames the given elements that should not be in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames contains any given java.lang.CharSequence elements.
+   */
+  public PlayerAssert doesNotHavePreviousNames(java.lang.CharSequence... previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence varargs is not null.
+    if (previousNames == null) failWithMessage("Expecting previousNames parameter not to be null.");
+
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getPreviousNames(), previousNames);
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's previousNames does not contain the given java.lang.CharSequence elements in Collection.
+   *
+   * @param previousNames the given elements that should not be in actual Player's previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames contains any given java.lang.CharSequence elements.
+   */
+  public PlayerAssert doesNotHavePreviousNames(java.util.Collection<? extends java.lang.CharSequence> previousNames) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // check that given java.lang.CharSequence collection is not null.
+    if (previousNames == null) {
+      failWithMessage("Expecting previousNames parameter not to be null.");
+      return this; // to fool Eclipse "Null pointer access" warning on toArray.
+    }
+
+    // check with standard error message (use overridingErrorMessage before contains to set your own message).
+    Iterables.instance().assertDoesNotContain(info, actual.getPreviousNames(), previousNames.toArray());
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player has no previousNames.
+   * @return this assertion object.
+   * @throws AssertionError if the actual Player's previousNames is not empty.
+   */
+  public PlayerAssert hasNoPreviousNames() {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // we override the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting :\n  <%s>\nnot to have previousNames but had :\n  <%s>";
+
+    // check
+    if (actual.getPreviousNames().iterator().hasNext()) {
+      failWithMessage(assertjErrorMessage, actual, actual.getPreviousNames());
+    }
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+
+  /**
    * Verifies that the actual Player's previousTeamNames contains the given String elements.
    * @param previousTeamNames the given elements that should be contained in actual Player's previousTeamNames.
    * @return this assertion object.


### PR DESCRIPTION
Fixes #133 by handling "interface" in the same way as "class" in pulling out generic types.