### PR TITLE
Update Readme with info about the gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 The Assertions Generator can create specific assertions for your classes. It comes with :
 * a CLI tool (this project) 
-* a [**maven plugin**](https://github.com/joel-costigliola/assertj-assertions-generator-maven-plugin).
+* a [**maven plugin**](https://github.com/assertj/assertj-assertions-generator-maven-plugin).
+* a [**gradle plugin**](https://github.com/assertj/assertj-generator-gradle-plugin).
 
 Let's say you have a `Player` class with `name` and `team` properties. The generator will create a `PlayerAssert` assertions class with `hasName` and `hasTeam` assertions. This allows you to write :
 


### PR DESCRIPTION
This MR updates README:
+ info about gradle plugin
+ update link to maven plugin

Given that `assertj-assertions-generator` repo could be entry point for some-one looking for gradle plugin it make sense to have it mentioned together with maven plugin.