### PR TITLE
Add support for Record-like getters

### DIFF
--- a/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
+++ b/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
@@ -772,10 +772,12 @@ public class ClassUtil {
     return memberName;
   }
 
-  private static String getterProperty(String memberName) {
+  public static String getterProperty(String memberName) {
     if (memberName.startsWith(GET_PREFIX)) {
       String propertyWithCapitalLetter = removeStart(memberName, GET_PREFIX);
-      return uncapitalize(propertyWithCapitalLetter);
+      if (!propertyWithCapitalLetter.isEmpty()) {
+        return uncapitalize(propertyWithCapitalLetter);
+      }
     }
     return memberName;
   }

--- a/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
+++ b/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
@@ -158,7 +158,7 @@ public class ClassUtil {
   }
 
   private static Set<TypeToken<?>> getPackageClassesFromClasspathJars(String packageName, ClassLoader classLoader)
-          throws IOException {
+                                                                                                                   throws IOException {
     ImmutableSet<ClassInfo> classesInfo = ClassPath.from(classLoader).getTopLevelClassesRecursive(packageName);
     Set<TypeToken<?>> classesInPackage = new HashSet<>();
     for (ClassInfo classInfo : classesInfo) {
@@ -191,7 +191,7 @@ public class ClassUtil {
       throw new RuntimeException(packageName + " does not appear to be a valid package (Unsupported encoding)", e);
     } catch (IOException ioException) {
       throw new RuntimeException("IOException was thrown when trying to get all classes for " + packageName,
-              ioException);
+                                 ioException);
     }
   }
 
@@ -207,7 +207,7 @@ public class ClassUtil {
    * @throws UnsupportedEncodingException thrown by {@link URLDecoder#decode(String, String)}
    */
   private static Set<TypeToken<?>> getClassesInDirectory(File directory, String packageName, ClassLoader classLoader)
-          throws UnsupportedEncodingException {
+                                                                                                                      throws UnsupportedEncodingException {
     Set<TypeToken<?>> classes = new LinkedHashSet<>();
 
     // Capture all the .class files in this directory
@@ -250,8 +250,8 @@ public class ClassUtil {
     if (isPackageInfo(typeToken)) return false;
     Class<?> raw = typeToken.getRawType();
     return (includePrivate || isPublic(raw.getModifiers()))
-            && !raw.isAnonymousClass()
-            && !raw.isLocalClass();
+           && !raw.isAnonymousClass()
+           && !raw.isLocalClass();
   }
 
   private static boolean isPackageInfo(TypeToken<?> typeToken) {
@@ -317,9 +317,9 @@ public class ClassUtil {
 
   public static boolean isGetter(Method method) {
     return !Void.TYPE.equals(method.getReturnType())
-            && method.getParameterTypes().length == 0
-            && !isForbiddenGetter(method)
-            && !isReturnGeneric(method);
+           && method.getParameterTypes().length == 0
+           && !isForbiddenGetter(method)
+           && !isReturnGeneric(method);
   }
 
   private static boolean isForbiddenGetter(Method method) {
@@ -361,8 +361,8 @@ public class ClassUtil {
 
   public static boolean isPredicate(Method method) {
     return isValidPredicateName(method.getName())
-            && isBoolean(method.getReturnType())
-            && method.getParameterTypes().length == 0;
+           && isBoolean(method.getReturnType())
+           && method.getParameterTypes().length == 0;
   }
 
   private static boolean isBoolean(Class<?> type) {
@@ -371,8 +371,8 @@ public class ClassUtil {
 
   private static boolean isAnnotated(Method method, Set<Class<?>> includeAnnotations, boolean isClassAnnotated) {
     if (!Void.TYPE.equals(method.getReturnType())
-            && method.getParameterTypes().length == 0
-            && !isStatic(method.getModifiers())) {
+        && method.getParameterTypes().length == 0
+        && !isStatic(method.getModifiers())) {
       Annotation[] methodAnnotations = method.getAnnotations();
       return isClassAnnotated || containsAny(methodAnnotations, includeAnnotations);
     }
@@ -403,15 +403,15 @@ public class ClassUtil {
 
   static {
     String[][] predicates = {
-            { "is", "isNot" },
-            { "was", "wasNot" },
-            { "can", "cannot" },
-            { "canBe", "cannotBe" },
-            { "should", "shouldNot" },
-            { "shouldBe", "shouldNotBe" },
-            { "has", "doesNotHave" },
-            { "willBe", "willNotBe" },
-            { "will", "willNot" },
+        { "is", "isNot" },
+        { "was", "wasNot" },
+        { "can", "cannot" },
+        { "canBe", "cannotBe" },
+        { "should", "shouldNot" },
+        { "shouldBe", "shouldNotBe" },
+        { "has", "doesNotHave" },
+        { "willBe", "willNotBe" },
+        { "will", "willNot" },
     };
     StringBuilder pattern = new StringBuilder("^(?:get");
     Map<String, String> map = new HashMap<>();
@@ -465,8 +465,8 @@ public class ClassUtil {
     Set<Method> getters = new TreeSet<>(GETTER_COMPARATOR);
     for (Method method : methods) {
       if (isPublic(method.getModifiers())
-              && isNotDefinedInObjectClass(method)
-              && isGetter(method, includeAnnotations, isClassAnnotated)) {
+          && isNotDefinedInObjectClass(method)
+          && isGetter(method, includeAnnotations, isClassAnnotated)) {
         getters.add(method);
       }
     }
@@ -475,8 +475,8 @@ public class ClassUtil {
 
   private static boolean isGetter(Method method, Set<Class<?>> includeAnnotations, boolean isClassAnnotated) {
     return isGetter(method)
-            || isPredicate(method)
-            || isAnnotated(method, includeAnnotations, isClassAnnotated);
+           || isPredicate(method)
+           || isAnnotated(method, includeAnnotations, isClassAnnotated);
   }
 
   public static List<Field> nonStaticFieldsOf(TypeToken<?> clazz) {
@@ -589,7 +589,7 @@ public class ClassUtil {
     } else if (type instanceof WildcardType) {
       final WildcardType wildcardType = (WildcardType) type;
       return wildcardType.getUpperBounds() != null ? getClass(wildcardType.getUpperBounds()[0])
-              : wildcardType.getLowerBounds() != null ? getClass(wildcardType.getLowerBounds()[0]) : null;
+          : wildcardType.getLowerBounds() != null ? getClass(wildcardType.getLowerBounds()[0]) : null;
     } else if (type instanceof TypeVariable) {
       final TypeVariable<?> typeVariable = (TypeVariable<?>) type;
       final Type[] bounds = typeVariable.getBounds();
@@ -606,7 +606,7 @@ public class ClassUtil {
    */
   public static boolean isInnerPackageOf(Package child, Package parent) {
     return child != null && parent != null
-            && child.getName().startsWith(parent.getName());
+           && child.getName().startsWith(parent.getName());
   }
 
   /**

--- a/src/test/java/org/assertj/assertions/generator/data/nba/Player.java
+++ b/src/test/java/org/assertj/assertions/generator/data/nba/Player.java
@@ -60,7 +60,7 @@ public class Player {
     this.isDisabled = isDisabled;
   }
 
-  public Name getName() {
+  public Name name() {
     return name;
   }
 

--- a/src/test/java/org/assertj/assertions/generator/description/GetterDescriptionTest.java
+++ b/src/test/java/org/assertj/assertions/generator/description/GetterDescriptionTest.java
@@ -55,7 +55,7 @@ public class GetterDescriptionTest {
 
   @Test
   public void should_create_valid_typename_from_class_for_user_defined_type_in_different_package() throws Exception {
-    getterDescription = new GetterDescription("name", PLAYER_TYPE_DESCRIPTION, Player.class.getMethod("getName"));
+    getterDescription = new GetterDescription("name", PLAYER_TYPE_DESCRIPTION, Player.class.getMethod("name"));
     assertThat(getterDescription.getName()).isEqualTo("name");
     assertThat(getterDescription.getTypeName()).isEqualTo("org.assertj.assertions.generator.data.Name");
     assertThat(getterDescription.getFullyQualifiedTypeName()).isEqualTo("org.assertj.assertions.generator.data.Name");

--- a/src/test/java/org/assertj/assertions/generator/description/converter/ClassToClassDescriptionConverterTest.java
+++ b/src/test/java/org/assertj/assertions/generator/description/converter/ClassToClassDescriptionConverterTest.java
@@ -61,7 +61,7 @@ public class ClassToClassDescriptionConverterTest implements NestedClassesTest, 
     assertThat(classDescription.getFullyQualifiedClassName()).isEqualTo("org.assertj.assertions.generator.data.nba.Player");
     assertThat(classDescription.getFullyQualifiedOuterClassName()).isEqualTo("org.assertj.assertions.generator.data.nba.Player");
     assertThat(classDescription.getFullyQualifiedClassNameWithoutGenerics()).isEqualTo(classDescription.getFullyQualifiedClassName());
-    assertThat(classDescription.getGettersDescriptions()).hasSize(19);
+    assertThat(classDescription.getGettersDescriptions()).hasSize(21);
     assertThat(classDescription.getAssertClassName()).isEqualTo("PlayerAssert");
     assertThat(classDescription.getAssertClassFilename()).isEqualTo("PlayerAssert.java");
     assertThat(classDescription.getFullyQualifiedAssertClassName()).isEqualTo("org.assertj.assertions.generator.data.nba.PlayerAssert");

--- a/src/test/java/org/assertj/assertions/generator/util/ClassUtilTest.java
+++ b/src/test/java/org/assertj/assertions/generator/util/ClassUtilTest.java
@@ -22,6 +22,7 @@ import static org.assertj.assertions.generator.util.ClassUtil.getNegativePredica
 import static org.assertj.assertions.generator.util.ClassUtil.getPredicatePrefix;
 import static org.assertj.assertions.generator.util.ClassUtil.getSimpleNameWithOuterClass;
 import static org.assertj.assertions.generator.util.ClassUtil.getterMethodsOf;
+import static org.assertj.assertions.generator.util.ClassUtil.getterProperty;
 import static org.assertj.assertions.generator.util.ClassUtil.inheritsCollectionOrIsIterable;
 import static org.assertj.assertions.generator.util.ClassUtil.isBoolean;
 import static org.assertj.assertions.generator.util.ClassUtil.isInnerPackageOf;
@@ -264,6 +265,13 @@ public class ClassUtilTest implements NestedClassesTest {
     Set<Method> playerGetterMethods = declaredGetterMethodsOf(TypeToken.of(Movie.class), Collections.<Class<?>> emptySet());
     assertThat(playerGetterMethods).contains(Movie.class.getMethod("getReleaseDate", NO_PARAMS))
                                    .doesNotContain(ArtWork.class.getMethod("getTitle", NO_PARAMS));
+  }
+
+  @Test
+  public void should_return_property_name_from_getter_method_name() throws Exception {
+    assertThat(getterProperty("getName")).isEqualTo("name");
+    assertThat(getterProperty("name")).isEqualTo("name");
+    assertThat(getterProperty("get")).isEqualTo("get");
   }
 
   @Theory

--- a/src/test/java/org/assertj/assertions/generator/util/ClassUtilTest.java
+++ b/src/test/java/org/assertj/assertions/generator/util/ClassUtilTest.java
@@ -28,7 +28,7 @@ import static org.assertj.assertions.generator.util.ClassUtil.isBoolean;
 import static org.assertj.assertions.generator.util.ClassUtil.isInnerPackageOf;
 import static org.assertj.assertions.generator.util.ClassUtil.isJavaLangType;
 import static org.assertj.assertions.generator.util.ClassUtil.isPredicate;
-import static org.assertj.assertions.generator.util.ClassUtil.isStandardGetter;
+import static org.assertj.assertions.generator.util.ClassUtil.isGetter;
 import static org.assertj.assertions.generator.util.ClassUtil.isValidGetterName;
 import static org.assertj.assertions.generator.util.ClassUtil.propertyNameOf;
 import static org.assertj.assertions.generator.util.ClassUtil.resolveTypeNameInPackage;
@@ -182,14 +182,15 @@ public class ClassUtilTest implements NestedClassesTest {
 
   @Test
   public void should_return_true_if_method_is_a_standard_getter() throws Exception {
-    assertThat(isStandardGetter(Player.class.getMethod("getTeam", NO_PARAMS))).isTrue();
+    assertThat(isGetter(Player.class.getMethod("getTeam", NO_PARAMS))).isTrue();
+    assertThat(isGetter(Player.class.getMethod("isRookie", NO_PARAMS))).isTrue();
+    assertThat(isGetter(Player.class.getMethod("name", NO_PARAMS))).isTrue();
   }
 
   @Test
   public void should_return_false_if_method_is_not_a_standard_getter() throws Exception {
-    assertThat(isStandardGetter(Player.class.getMethod("isRookie", NO_PARAMS))).isFalse();
-    assertThat(isStandardGetter(Player.class.getMethod("getVoid", NO_PARAMS))).isFalse();
-    assertThat(isStandardGetter(Player.class.getMethod("getWithParam", String.class))).isFalse();
+    assertThat(isGetter(Player.class.getMethod("getVoid", NO_PARAMS))).isFalse();
+    assertThat(isGetter(Player.class.getMethod("getWithParam", String.class))).isFalse();
   }
 
   @Test

--- a/src/test/resources/AbstractAnnotatedClassAssert.expected.txt
+++ b/src/test/resources/AbstractAnnotatedClassAssert.expected.txt
@@ -86,4 +86,27 @@ public abstract class AbstractAnnotatedClassAssert<S extends AbstractAnnotatedCl
     return myself;
   }
 
+  /**
+   * Verifies that the actual AnnotatedClass's thisIsNotAProperty is equal to the given one.
+   * @param thisIsNotAProperty the given thisIsNotAProperty to compare the actual AnnotatedClass's thisIsNotAProperty to.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual AnnotatedClass's thisIsNotAProperty is not equal to the given one.
+   */
+  public S hasThisIsNotAProperty(boolean thisIsNotAProperty) {
+    // check that actual AnnotatedClass we want to make assertions on is not null.
+    isNotNull();
+
+    // overrides the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting thisIsNotAProperty of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+
+    // check
+    boolean actualThisIsNotAProperty = actual.thisIsNotAProperty();
+    if (actualThisIsNotAProperty != thisIsNotAProperty) {
+      failWithMessage(assertjErrorMessage, actual, thisIsNotAProperty, actualThisIsNotAProperty);
+    }
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
 }

--- a/src/test/resources/AbstractPlayerAssert.expected.txt
+++ b/src/test/resources/AbstractPlayerAssert.expected.txt
@@ -115,6 +115,52 @@ public abstract class AbstractPlayerAssert<S extends AbstractPlayerAssert<S, A>,
   }
 
   /**
+   * Verifies that the actual Player's get is equal to the given one.
+   * @param get the given get to compare the actual Player's get to.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual Player's get is not equal to the given one.
+   */
+  public S hasGet(String get) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // overrides the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting get of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+
+    // null safe check
+    String actualGet = actual.get();
+    if (!Objects.deepEquals(actualGet, get)) {
+      failWithMessage(assertjErrorMessage, actual, get, actualGet);
+    }
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's is is equal to the given one.
+   * @param is the given is to compare the actual Player's is to.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual Player's is is not equal to the given one.
+   */
+  public S hasIs(String is) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // overrides the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting is of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+
+    // null safe check
+    String actualIs = actual.is();
+    if (!Objects.deepEquals(actualIs, is)) {
+      failWithMessage(assertjErrorMessage, actual, is, actualIs);
+    }
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
    * Verifies that the actual Player's name is equal to the given one.
    * @param name the given name to compare the actual Player's name to.
    * @return this assertion object.
@@ -128,7 +174,7 @@ public abstract class AbstractPlayerAssert<S extends AbstractPlayerAssert<S, A>,
     String assertjErrorMessage = "\nExpecting name of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
 
     // null safe check
-    org.assertj.assertions.generator.data.Name actualName = actual.getName();
+    org.assertj.assertions.generator.data.Name actualName = actual.name();
     if (!Objects.deepEquals(actualName, name)) {
       failWithMessage(assertjErrorMessage, actual, name, actualName);
     }

--- a/src/test/resources/AbstractPlayerAssert.generated.in.custom.package.expected.txt
+++ b/src/test/resources/AbstractPlayerAssert.generated.in.custom.package.expected.txt
@@ -116,6 +116,52 @@ public abstract class AbstractPlayerAssert<S extends AbstractPlayerAssert<S, A>,
   }
 
   /**
+   * Verifies that the actual Player's get is equal to the given one.
+   * @param get the given get to compare the actual Player's get to.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual Player's get is not equal to the given one.
+   */
+  public S hasGet(String get) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // overrides the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting get of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+
+    // null safe check
+    String actualGet = actual.get();
+    if (!Objects.deepEquals(actualGet, get)) {
+      failWithMessage(assertjErrorMessage, actual, get, actualGet);
+    }
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual Player's is is equal to the given one.
+   * @param is the given is to compare the actual Player's is to.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual Player's is is not equal to the given one.
+   */
+  public S hasIs(String is) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // overrides the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting is of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+
+    // null safe check
+    String actualIs = actual.is();
+    if (!Objects.deepEquals(actualIs, is)) {
+      failWithMessage(assertjErrorMessage, actual, is, actualIs);
+    }
+
+    // return the current assertion for method chaining
+    return myself;
+  }
+
+  /**
    * Verifies that the actual Player's name is equal to the given one.
    * @param name the given name to compare the actual Player's name to.
    * @return this assertion object.
@@ -129,7 +175,7 @@ public abstract class AbstractPlayerAssert<S extends AbstractPlayerAssert<S, A>,
     String assertjErrorMessage = "\nExpecting name of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
 
     // null safe check
-    org.assertj.assertions.generator.data.Name actualName = actual.getName();
+    org.assertj.assertions.generator.data.Name actualName = actual.name();
     if (!Objects.deepEquals(actualName, name)) {
       failWithMessage(assertjErrorMessage, actual, name, actualName);
     }

--- a/src/test/resources/AnnotatedClassAssert.flat.expected.txt
+++ b/src/test/resources/AnnotatedClassAssert.flat.expected.txt
@@ -97,4 +97,27 @@ public class AnnotatedClassAssert extends AbstractObjectAssert<AnnotatedClassAss
     return this;
   }
 
+  /**
+   * Verifies that the actual AnnotatedClass's thisIsNotAProperty is equal to the given one.
+   * @param thisIsNotAProperty the given thisIsNotAProperty to compare the actual AnnotatedClass's thisIsNotAProperty to.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual AnnotatedClass's thisIsNotAProperty is not equal to the given one.
+   */
+  public AnnotatedClassAssert hasThisIsNotAProperty(boolean thisIsNotAProperty) {
+    // check that actual AnnotatedClass we want to make assertions on is not null.
+    isNotNull();
+
+    // overrides the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting thisIsNotAProperty of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+
+    // check
+    boolean actualThisIsNotAProperty = actual.thisIsNotAProperty();
+    if (actualThisIsNotAProperty != thisIsNotAProperty) {
+      failWithMessage(assertjErrorMessage, actual, thisIsNotAProperty, actualThisIsNotAProperty);
+    }
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
 }

--- a/src/test/resources/PlayerAssert.flat.expected.txt
+++ b/src/test/resources/PlayerAssert.flat.expected.txt
@@ -126,6 +126,52 @@ public class PlayerAssert extends AbstractObjectAssert<PlayerAssert, Player> {
   }
 
   /**
+   * Verifies that the actual Player's get is equal to the given one.
+   * @param get the given get to compare the actual Player's get to.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual Player's get is not equal to the given one.
+   */
+  public PlayerAssert hasGet(String get) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // overrides the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting get of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+
+    // null safe check
+    String actualGet = actual.get();
+    if (!Objects.deepEquals(actualGet, get)) {
+      failWithMessage(assertjErrorMessage, actual, get, actualGet);
+    }
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's is is equal to the given one.
+   * @param is the given is to compare the actual Player's is to.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual Player's is is not equal to the given one.
+   */
+  public PlayerAssert hasIs(String is) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // overrides the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting is of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+
+    // null safe check
+    String actualIs = actual.is();
+    if (!Objects.deepEquals(actualIs, is)) {
+      failWithMessage(assertjErrorMessage, actual, is, actualIs);
+    }
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
    * Verifies that the actual Player's name is equal to the given one.
    * @param name the given name to compare the actual Player's name to.
    * @return this assertion object.
@@ -139,7 +185,7 @@ public class PlayerAssert extends AbstractObjectAssert<PlayerAssert, Player> {
     String assertjErrorMessage = "\nExpecting name of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
 
     // null safe check
-    org.assertj.assertions.generator.data.Name actualName = actual.getName();
+    org.assertj.assertions.generator.data.Name actualName = actual.name();
     if (!Objects.deepEquals(actualName, name)) {
       failWithMessage(assertjErrorMessage, actual, name, actualName);
     }

--- a/src/test/resources/PlayerAssert.generated.in.custom.package.flat.expected.txt
+++ b/src/test/resources/PlayerAssert.generated.in.custom.package.flat.expected.txt
@@ -127,6 +127,52 @@ public class PlayerAssert extends AbstractObjectAssert<PlayerAssert, Player> {
   }
 
   /**
+   * Verifies that the actual Player's get is equal to the given one.
+   * @param get the given get to compare the actual Player's get to.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual Player's get is not equal to the given one.
+   */
+  public PlayerAssert hasGet(String get) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // overrides the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting get of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+
+    // null safe check
+    String actualGet = actual.get();
+    if (!Objects.deepEquals(actualGet, get)) {
+      failWithMessage(assertjErrorMessage, actual, get, actualGet);
+    }
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
+   * Verifies that the actual Player's is is equal to the given one.
+   * @param is the given is to compare the actual Player's is to.
+   * @return this assertion object.
+   * @throws AssertionError - if the actual Player's is is not equal to the given one.
+   */
+  public PlayerAssert hasIs(String is) {
+    // check that actual Player we want to make assertions on is not null.
+    isNotNull();
+
+    // overrides the default error message with a more explicit one
+    String assertjErrorMessage = "\nExpecting is of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+
+    // null safe check
+    String actualIs = actual.is();
+    if (!Objects.deepEquals(actualIs, is)) {
+      failWithMessage(assertjErrorMessage, actual, is, actualIs);
+    }
+
+    // return the current assertion for method chaining
+    return this;
+  }
+
+  /**
    * Verifies that the actual Player's name is equal to the given one.
    * @param name the given name to compare the actual Player's name to.
    * @return this assertion object.
@@ -140,7 +186,7 @@ public class PlayerAssert extends AbstractObjectAssert<PlayerAssert, Player> {
     String assertjErrorMessage = "\nExpecting name of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
 
     // null safe check
-    org.assertj.assertions.generator.data.Name actualName = actual.getName();
+    org.assertj.assertions.generator.data.Name actualName = actual.name();
     if (!Objects.deepEquals(actualName, name)) {
       failWithMessage(assertjErrorMessage, actual, name, actualName);
     }


### PR DESCRIPTION
The rule for identifying getters has been modified to support record-like getters (#212). 
Now, any method that takes no parameters and returns a type other than void is considered a getter. 
Automatic generation has been disabled for methods returning a generic type (such as T or List<T>). 
Additionally, an issue with generating asserts with an empty parameter name for the get() method (#216) has been fixed.

* Closes #212
* Closes #216